### PR TITLE
Add GraphQL setup and change UI theme

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_GRAPHQL_URL=https://your-graphql-endpoint.com/graphql

--- a/src/@core/theme/index.js
+++ b/src/@core/theme/index.js
@@ -1,4 +1,3 @@
-// Next Imports
 import { Public_Sans } from 'next/font/google'
 
 // Theme Options Imports
@@ -35,7 +34,20 @@ const theme = (settings, mode, direction) => {
       dark: '225 222 245',
       lightShadow: '47 43 61',
       darkShadow: '19 17 32'
-    }
+    },
+    locale: 'id-ID',
+    palette: {
+      primary: {
+        main: '#0D47A1',
+      },
+      secondary: {
+        main: '#1976D2',
+      },
+      background: {
+        default: '#E3F2FD',
+        paper: '#FFFFFF',
+      },
+    },
   }
 }
 

--- a/src/components/Providers.jsx
+++ b/src/components/Providers.jsx
@@ -1,3 +1,6 @@
+import { ApolloProvider } from '@apollo/client';
+import client from 'src/graphql/client';
+
 // Context Imports
 import { VerticalNavProvider } from '@menu/contexts/verticalNavContext'
 import { SettingsProvider } from '@core/contexts/settingsContext'
@@ -19,7 +22,9 @@ const Providers = async props => {
     <VerticalNavProvider>
       <SettingsProvider settingsCookie={settingsCookie} mode={mode}>
         <ThemeProvider direction={direction} systemMode={systemMode}>
-          {children}
+          <ApolloProvider client={client}>
+            {children}
+          </ApolloProvider>
         </ThemeProvider>
       </SettingsProvider>
     </VerticalNavProvider>

--- a/src/graphql/client.js
+++ b/src/graphql/client.js
@@ -1,0 +1,8 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+
+const client = new ApolloClient({
+  uri: 'https://your-graphql-endpoint.com/graphql',
+  cache: new InMemoryCache()
+});
+
+export default client;

--- a/src/views/Login.jsx
+++ b/src/views/Login.jsx
@@ -59,6 +59,9 @@ const MaskImg = styled('img')({
 const LoginV2 = ({ mode }) => {
   // States
   const [isPasswordShown, setIsPasswordShown] = useState(false)
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
 
   // Vars
   const darkImg = '/images/pages/auth-mask-dark.png'
@@ -85,8 +88,24 @@ const LoginV2 = ({ mode }) => {
 
   const handleClickShowPassword = () => setIsPasswordShown(show => !show)
 
-  const handleLogin = role => {
-    router.push(`/${role}`)
+  const handleLogin = async e => {
+    e.preventDefault()
+    setError('')
+
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ username, password })
+    })
+
+    if (res.ok) {
+      const data = await res.json()
+      router.push(`/${data.user.role}`)
+    } else {
+      setError('Invalid username or password')
+    }
   }
 
   return (
@@ -120,19 +139,25 @@ const LoginV2 = ({ mode }) => {
           <form
             noValidate
             autoComplete='off'
-            onSubmit={e => {
-              e.preventDefault()
-              router.push('/')
-            }}
+            onSubmit={handleLogin}
             className='flex flex-col gap-5'
           >
-            <CustomTextField autoFocus fullWidth label='Email or Username' placeholder='Enter your email or username' />
+            <CustomTextField 
+              autoFocus 
+              fullWidth 
+              label='Username' 
+              placeholder='Enter your username' 
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+            />
             <CustomTextField
               fullWidth
               label='Password'
               placeholder='············'
               id='outlined-adornment-password'
               type={isPasswordShown ? 'text' : 'password'}
+              value={password}
+              onChange={e => setPassword(e.target.value)}
               slotProps={{
                 input: {
                   endAdornment: (
@@ -145,6 +170,7 @@ const LoginV2 = ({ mode }) => {
                 }
               }}
             />
+            {error && <Typography color='error'>{error}</Typography>}
             <div className='flex justify-between items-center gap-x-3 gap-y-1 flex-wrap'>
               <FormControlLabel control={<Checkbox />} label='Remember me' />
               <Typography className='text-end' color='primary.main' component={Link}>
@@ -176,23 +202,6 @@ const LoginV2 = ({ mode }) => {
               </IconButton>
             </div>
           </form>
-          <div className='flex flex-col gap-2 mt-4'>
-            <Button fullWidth variant='outlined' onClick={() => handleLogin('admin')}>
-              Login as Admin
-            </Button>
-            <Button fullWidth variant='outlined' onClick={() => handleLogin('student')}>
-              Login as Student
-            </Button>
-            <Button fullWidth variant='outlined' onClick={() => handleLogin('faculty')}>
-              Login as Faculty
-            </Button>
-            <Button fullWidth variant='outlined' onClick={() => handleLogin('study-program')}>
-              Login as Study Program
-            </Button>
-            <Button fullWidth variant='outlined' onClick={() => handleLogin('administration')}>
-              Login as Administration
-            </Button>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Add GraphQL setup using ApolloClient and InMemoryCache, and update login functionality and UI theme.

* **GraphQL Setup**: 
  - Add `src/graphql/client.js` to set up `ApolloClient` and `InMemoryCache`.
  - Export the `ApolloClient` instance from `src/graphql/client.js`.
  - Update `src/components/Providers.jsx` to include the ApolloProvider and wrap the application with it.

* **Environment Variable**:
  - Add `.env` file to store the GraphQL endpoint URL.

* **Login Functionality**:
  - Remove buttons for different roles in `src/views/Login.jsx`.
  - Adjust the login form to use `/api/login` endpoint.
  - Add fields for username and password.
  - Handle error when username and password are incorrect.

* **UI Theme**:
  - Change the UI theme to Indonesian with a campus theme in `src/@core/theme/index.js`.

