### PR TITLE
Add date utils for Indonesian format

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -4,6 +4,7 @@ import 'react-perfect-scrollbar/dist/css/styles.css'
 
 import { ApolloWrapper } from './ApolloWrapper'
 import { getSystemMode } from '@core/utils/serverHelpers'
+import { formatDateToIndonesian } from '@/utils/dateUtils';
 
 import '@/app/globals.css'
 
@@ -21,6 +22,8 @@ const RootLayout = async props => {
 
   const systemMode = await getSystemMode()
   const direction = 'ltr'
+
+  const formattedDate = formatDateToIndonesian(new Date());
 
   return (
     <html id='__next' lang='en' dir={direction} suppressHydrationWarning>

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,0 +1,8 @@
+import dayjs from 'dayjs';
+import 'dayjs/locale/id';
+
+dayjs.locale('id');
+
+export function formatDateToIndonesian(date) {
+  return dayjs(date).format('dddd, DD MMMM YYYY');
+}


### PR DESCRIPTION
Add a utility function to format date days in Indonesian and update relevant files to use it.

* **Add `src/utils/dateUtils.js`**:
  - Import `dayjs` and set the locale to 'id'.
  - Define and export the `formatDateToIndonesian` function using `dayjs` to format the date in Indonesian.

* **Modify `src/app/layout.jsx`**:
  - Import the `formatDateToIndonesian` function.
  - Use the `formatDateToIndonesian` function to format the current date globally.

